### PR TITLE
remove the link to cypherpunk wiki

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -5,7 +5,7 @@ pagination_next: null
 pagination_prev: null
 ---
 
-Logos is a continuation of the original [cypherpunk](https://en.wikipedia.org/wiki/Cypherpunk) movement, advocating the widespread use of strong cryptography and privacy-enhancing technologies as a route to social and political change.
+Logos is a continuation of the original cypherpunk movement, advocating the widespread use of strong cryptography and privacy-enhancing technologies as a route to social and political change.
 
 We believe trust-minimized technologies will pave the way to a world where more humane social institutions and fairer means of governance can emerge, and are accessible to anyone in the world with an internet connection.
 


### PR DESCRIPTION
Remove a link to the cypherpunk wiki after the group call discussion : https://www.notion.so/About-page-should-we-link-to-the-Cypherpunk-manifesto-instead-of-Wiki-https-nakamotoinstitute-or-36e56049f25f478e92e2ad9fd4a4329f