### PR TITLE
Add Nix Flakes to CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,12 +40,12 @@ pipeline {
       steps {
         sshagent(credentials: ['status-im-auto-ssh']) {
           script {
-            nix.develop('''
+            nix.develop("""
               ghp-import \
                 -b ${deployBranch()} \
                 -c ${deployDomain()} \
                 -p build
-              '''
+              """
             )
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,13 +39,16 @@ pipeline {
     stage('Publish') {
       steps {
         sshagent(credentials: ['status-im-auto-ssh']) {
-          sh """
-            ghp-import \
-              -b ${deployBranch()} \
-              -c ${deployDomain()} \
-              -p build
-          """
-         }
+          script {
+            nix.develop('''
+              ghp-import \
+                -b ${deployBranch()} \
+                -c ${deployDomain()} \
+                -p build
+              '''
+            )
+          }
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,15 +20,17 @@ pipeline {
 
   stages {
     stage('Install') {
-      steps {
-        sh 'yarn install'
+      steps { 
+        script {
+          nix.develop('yarn install')
+        }
       }
     }
 
     stage('Build') {
       steps {
         script {
-          sh 'yarn build'
+          nix.develop('yarn build')
           jenkins.genBuildMetaJSON('build/build.json')
         }
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721548954,
+        "narHash": "sha256-7cCC8+Tdq1+3OPyc3+gVo9dzUNkNIQfwSDJ2HSi2u3o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63d37ccd2d178d54e7fb691d7ec76000740ea24a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-24.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,21 +5,28 @@
     nixpkgs.url = "nixpkgs/nixos-24.05";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
-        supportedSystems = ["x86_64-linux"  "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
-        forEach = nixpkgs.lib.genAttrs supportedSystems;
-        pkgsFor = nixpkgs.lib.genAttrs supportedSystems (
-            system: import nixpkgs { inherit system; }
-        );
-      in rec {
-        devShells = forEach (system: {
-            default = pkgsFor.${system}.mkShellNoCC {
-                packages = with pkgsFor.${system}.buildPackages; [
-                    yarn # 1.22.22 
-                    nodejs # v20.15.1
-                ];
-            };
-        });
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = forEachSystem (system: import nixpkgs { inherit system; });
+    in
+    rec {
+      formatter = forEachSystem (system: pkgsFor.${system}.nixpkgs-fmt);
+
+      devShells = forEachSystem (system: {
+        default = pkgsFor.${system}.mkShellNoCC {
+          packages = with pkgsFor.${system}.buildPackages; [
+            yarn # 1.22.22
+            nodejs_20 # v20.15.1
+          ];
+        };
+      });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Flake file for logos website ";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-24.05";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+        supportedSystems = ["x86_64-linux"  "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+        forEach = nixpkgs.lib.genAttrs supportedSystems;
+        pkgsFor = nixpkgs.lib.genAttrs supportedSystems (
+            system: import nixpkgs { inherit system; }
+        );
+      in rec {
+        devShells = forEach (system: {
+            default = pkgsFor.${system}.mkShellNoCC {
+                packages = with pkgsFor.${system}.buildPackages; [
+                    yarn # 1.22.22 
+                    nodejs # v20.15.1
+                ];
+            };
+        });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
           packages = with pkgsFor.${system}.buildPackages; [
             yarn # 1.22.22
             nodejs_20 # v20.15.1
+            ghp-import # 2.1.0
           ];
         };
       });


### PR DESCRIPTION
### Description:
The PR introduces usage of Nix Flakes for the purpose of CI build. The goal is to have more control over the versions of tools which are being used within the CI and not depend on what is installed on the CI host.

### Related Issue(s):
[[Link to the related Issue(s), if any.]](https://github.com/status-im/infra-misc/issues/312)

### Changes Included:
- [ ] Bugfix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [x] Refactoring (a change that improves code quality and/or architecture)
- [ ] Other (explain below)

### Implementation Details:
By using flake.nix and flake.lock files we are controlling the versions of yarn and nodejs tools which are required by the 'Build' and 'Install' steps in the CI. In this way we won't be dependant on the versions of these tools which are installed on the CI hosts.

### Testing:
I have ran the CI for dev.logos.co which finished successfully and checked the dev.logos.co website afterwards.

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules