### PR TITLE
Remove top toast component from layout

### DIFF
--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -16,7 +16,7 @@ import LayoutProvider from '@theme/Layout/Provider'
 import ErrorPageContent from '@theme/ErrorPageContent'
 import type { Props } from '@theme/Layout'
 import styles from './styles.module.css'
-import TopToast from '@site/src/components/TopToast/TopToast'
+// import TopToast from '@site/src/components/TopToast/TopToast'
 
 export default function Layout(props: Props): ReactNode {
   const {
@@ -28,7 +28,7 @@ export default function Layout(props: Props): ReactNode {
     description,
   } = props
 
-  const [showTopToast, setShowTopToast] = React.useState(true)
+  const [showTopToast, setShowTopToast] = React.useState(false)
   const theme = useColorMode()
 
   useKeyboardNavigation()
@@ -41,12 +41,12 @@ export default function Layout(props: Props): ReactNode {
 
       <AnnouncementBar />
 
-      {showTopToast && (
+      {/* {showTopToast && (
         <TopToast
           colorMode={theme?.colorMode}
           setShowTopToast={setShowTopToast}
         />
-      )}
+      )} */}
 
       <div className={clsx(showTopToast && styles.toastMargin)}>
         <Navbar />


### PR DESCRIPTION
### Description:
Remove the TopToast component from the main layout to clean up the UI and remove unnecessary toast notifications.

### Changes Included:
- [x] Refactoring (a change that improves code quality and/or architecture)

### Implementation Details:
- Commented out TopToast import and component usage in Layout/index.tsx
- Set showTopToast state to false by default
- Removed conditional rendering of TopToast component
- Maintained toast margin styling for potential future use

Preview: https://logos-co-git-ui-updates-acidinfo.vercel.app/