### PR TITLE
[Hotfix] Update description for events to reflect Logos events

### DIFF
--- a/docs/events/index.mdx
+++ b/docs/events/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Events
-description: List of all Waku events
+description: List of all Logos events
 og:image_subtitle: Events
 ---
 


### PR DESCRIPTION
- Hotfix: This issue was found by Chair from the Waku team

<img width="446" height="321" alt="Screenshot 2025-10-29 at 9 03 15 AM" src="https://github.com/user-attachments/assets/59978795-3f22-4110-bfd7-87b3ea1f68e0" />

Changed from Waku to Logos